### PR TITLE
useability: handle rebases

### DIFF
--- a/lua/litee/gh/gitcli/init.lua
+++ b/lua/litee/gh/gitcli/init.lua
@@ -111,4 +111,13 @@ function M.git_show_and_write(commit, file, write_to)
     return out
 end
 
+function M.git_reset_hard(remote, branch)
+    local cmd = string.format([[git reset --hard %s/%s]], remote, branch)
+    local out = git_exec(cmd)
+    if out == nil then
+        return nil
+    end
+    return out
+end
+
 return M

--- a/lua/litee/gh/pr/diff_view.lua
+++ b/lua/litee/gh/pr/diff_view.lua
@@ -228,6 +228,14 @@ function M.on_refresh()
         return
     end
 
+    -- if the commit we are displaying no longer exists due to rebase or squash, render this
+    -- message out to diff buffers and return.
+    if s.pull_state.commits_by_sha[state.commit["sha"]] == nil then
+            vim.api.nvim_buf_set_lines(state.lbuf, 0, -1, false, {"Commit no longer exists"})
+            vim.api.nvim_buf_set_lines(state.rbuf, 0, -1, false, {"Commit no longer exists"})
+            return
+    end
+
     -- get latest threads
     state.threads = s.pull_state.review_threads_by_filename[state.file["filename"]]
 

--- a/lua/litee/gh/pr/handlers.lua
+++ b/lua/litee/gh/pr/handlers.lua
@@ -440,6 +440,15 @@ function M.commits_handler(sha, refresh)
     state.last_opened_commit = commit
 end
 
+local function commit_exists(sha) 
+    for _, c in ipairs(s.pull_state.commits) do
+        if c["sha"] == sha then
+            return true
+        end
+    end
+    return false
+end
+
 local function on_refresh()
         M.ui_handler(true)
 
@@ -451,7 +460,11 @@ local function on_refresh()
         then
             local tree = lib_tree.get_tree(comp_state.tree)
             local commit = tree["root"].commit
-            M.commits_handler(commit["sha"], true)
+            if not commit_exists(commit["sha"]) then
+                vim.cmd("GHCloseCommit")
+            else
+                M.commits_handler(commit["sha"], true)
+            end
         end
 
         -- refresh the "review" component if we have a valid tree, review is on tree's root.


### PR DESCRIPTION
this commit wires in some commit checks when doing a refresh to discern
if a squash or rebase occured.

if it does the repo is reset to its origin via `git reset --hard
{remote}/{branch}`

if the repository is dirty (you have made changes to some code under
review) the refresh will fail and ask you to stash them, keeping any
changes you've made while reviewing in place.

Signed-off-by: ldelossa <louis.delos@gmail.com>
