### PR TITLE
fix: remove unnecessary message on gh.nvim startup

### DIFF
--- a/lua/litee/gh/init.lua
+++ b/lua/litee/gh/init.lua
@@ -249,7 +249,6 @@ function M.start_refresh_timer(now)
     if now then
         M.refresh()
     end
-    vim.schedule(function() vim.api.nvim_echo({{"[gh.nvim] started backround refresh with interval " .. 180000/1000/60 .. " minutes", "LTInfo"}}, false, {}) end)
     M.refresh_timer:start(180000, 180000, function()
         M.refresh()
     end)


### PR DESCRIPTION
The refresh timer is started automatically after `require('litee.gh').setup({...})`, which is called on neovim startup for most users. It seems unneccessary to bother the user with information about the refresh timer.

This PR resolves #40.