### PR TITLE
feat: "GHNotifications" - implement a notifications buffer

### DIFF
--- a/lua/litee/gh/commands.lua
+++ b/lua/litee/gh/commands.lua
@@ -1,5 +1,6 @@
 local pr = require('litee.gh.pr')
 local dv = require('litee.gh.pr.diff_view')
+local noti = require('litee.gh.notifications')
 local pr_handlers = require('litee.gh.pr.handlers')
 local issues = require('litee.gh.issues')
 
@@ -34,6 +35,8 @@ function M.setup()
     vim.api.nvim_create_user_command("GHRefreshComments", pr_handlers.refresh_comments, {})
     -- refresh any open issue buffers, if a PR is opened, this will be ran as part of "GHRefreshPR"
     vim.api.nvim_create_user_command("GHRefreshIssues", issues.on_refresh, {})
+    -- refresh the notifications buffer if it is open.
+    vim.api.nvim_create_user_command("GHRefreshNotifications", noti.on_refresh, {})
     -- start a code review
     vim.api.nvim_create_user_command("GHStartReview", pr.start_review, {})
     -- submit all pending comments in a code review
@@ -77,6 +80,8 @@ function M.setup()
     -- Searches are always constrained to the repository Neovim is opened to.
     -- See: https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
     vim.api.nvim_create_user_command("GHSearchIssues", issues.search_issues, {})
+    -- 
+    vim.api.nvim_create_user_command("GHNotifications", noti.open_notifications, {})
 end
 
 return M

--- a/lua/litee/gh/ghcli/init.lua
+++ b/lua/litee/gh/ghcli/init.lua
@@ -789,6 +789,28 @@ function M.list_repo_contributors_async(on_read)
     async_request(args, on_read, true)
 end
 
+function M.list_repo_notifications(on_read)
+    local args = {
+        'api',
+        '-X',
+        'GET',
+        '-F',
+        'per_page=100',
+        "/repos/{owner}/{repo}/notifications"
+    }
+    async_request(args, on_read, true)
+end
+
+function M.set_notification_read(thread_id)
+    local cmd = [[gh api -X PATCH /notifications/threads/]] .. thread_id
+    return gh_exec(cmd, true)
+end
+
+function M.set_notification_ignored(thread_id)
+    local cmd = [[gh api -X PUT -F "ignored=true" /notifications/threads/]] .. thread_id .. "/subscription"
+    return gh_exec(cmd, true)
+end
+
 M.user = nil
 
 -- like get_user but caches the results on the first request and returns the 

--- a/lua/litee/gh/init.lua
+++ b/lua/litee/gh/init.lua
@@ -13,6 +13,7 @@ local pr                = require('litee.gh.pr')
 local pr_state          = require('litee.gh.pr.state')
 local pr_handlers       = require('litee.gh.pr.handlers')
 local issues            = require('litee.gh.issues')
+local noti              = require('litee.gh.notifications')
 -- unused, but must init the global completion function.
 local completion    = require('litee.gh.completion')
 
@@ -235,10 +236,10 @@ function M.refresh()
     if pr_state.pull_state ~= nil then
         -- will refresh any open issues too
         pr_handlers.on_refresh()
-        return
     else
         issues.on_refresh()
     end
+    noti.on_refresh()
 end
 
 -- refresh all data

--- a/lua/litee/gh/issues/preview.lua
+++ b/lua/litee/gh/issues/preview.lua
@@ -100,6 +100,7 @@ function M.render_issue(issue)
     end
     table.insert(buffer_lines, symbols.left)
     table.insert(buffer_lines, symbols.bottom)
+    table.insert(buffer_lines, "")
 
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})
     vim.api.nvim_buf_set_lines(buf, 0, #buffer_lines, false, buffer_lines)

--- a/lua/litee/gh/notifications/init.lua
+++ b/lua/litee/gh/notifications/init.lua
@@ -1,0 +1,60 @@
+local lib_notify  = require('litee.lib.notify')
+
+local ghcli       = require('litee.gh.ghcli')
+local noti_buffer = require('litee.gh.notifications.notifications_buffer')
+
+local M = {}
+
+M.state = nil
+
+function M.reset_state()
+    M.state = {
+        tab = nil,
+        win = nil,
+        buf = nil,
+    }
+end
+
+function M.open_notifications()
+    if 
+        M.state == nil or
+        not vim.api.nvim_win_is_valid(M.state.win) or
+        not vim.api.nvim_buf_is_valid(M.state.buf) 
+    then
+        M.reset_state()
+        vim.cmd("tabnew") 
+        M.state.tab = vim.api.nvim_get_current_tabpage()
+        M.state.win = vim.api.nvim_get_current_win()
+    end
+    ghcli.list_repo_notifications(function(err, data)
+        if err then
+            lib_notify.notify_popup_with_timeout("Failed to list notifications: " .. err, 7500, "error")
+            return
+        end
+        M.state.buf = noti_buffer.render_notifications(data)
+        vim.api.nvim_win_set_buf(M.state.win, M.state.buf)
+        vim.api.nvim_set_current_win(M.state.win)
+    end)
+end
+
+function M.on_refresh()
+    vim.schedule(function() 
+        if 
+            M.state == nil or
+            not vim.api.nvim_win_is_valid(M.state.win) or
+            not vim.api.nvim_buf_is_valid(M.state.buf) 
+        then
+            return
+        end
+        ghcli.list_repo_notifications(function(err, data)
+            if err then
+                lib_notify.notify_popup_with_timeout("Failed to list notifications: " .. err, 7500, "error")
+                return
+            end
+            M.state.buf = noti_buffer.render_notifications(data)
+            vim.api.nvim_win_set_buf(M.state.win, M.state.buf)
+        end)
+    end)
+end
+
+return M

--- a/lua/litee/gh/notifications/notifications_buffer.lua
+++ b/lua/litee/gh/notifications/notifications_buffer.lua
@@ -1,0 +1,235 @@
+local lib_notify    = require('litee.lib.notify')
+local lib_util      = require('litee.lib.util')
+local lib_util_path = require('litee.lib.util.path')
+
+local ghcli        = require('litee.gh.ghcli')
+local issues       = require('litee.gh.issues')
+local pr           = require('litee.gh.pr')
+local issues_preview = require('litee.gh.issues.preview')
+local config       = require('litee.gh.config')
+
+local M = {}
+
+local state = {
+    -- the buffer id where the thread is rendered
+    buf = nil,
+    -- a mapping between extmarks and their notification objects.
+    marks_to_notifications = {}
+}
+
+local function reset_state()
+    state.buf = nil
+    state.notifications_to_marks = nil
+end
+
+local symbols = {
+    top =    "╭",
+    left =   "│",
+    bottom = "╰",
+    tab = "  ",
+}
+
+local ns = vim.api.nvim_create_namespace("notification_buffer")
+
+local function _win_settings_on()
+    vim.api.nvim_win_set_option(0, 'wrap', false)
+    vim.api.nvim_win_set_option(0, 'number', false)
+end
+
+local function extract_issue_number(notification)
+    local url = notification["subject"]["url"]
+    if url == nil then
+        return nil
+    end
+    return lib_util_path.basename(url)
+end
+
+-- comment_under_cursor uses the mapped extmarks to extract the comment under
+-- the user's cursor.
+local function notification_under_cursor()
+    local cursor = vim.api.nvim_win_get_cursor(0)
+    local marks  = vim.api.nvim_buf_get_extmarks(0, ns, {cursor[1]-1, 0}, {-1, 0}, {
+        limit = 1
+    })
+    if #marks == 0 then
+        return
+    end
+    local mark = marks[1][1]
+    local comment = state.marks_to_notifications[mark]
+    return comment
+end
+
+local function preview_issue()
+    local noti = notification_under_cursor()
+    if noti == nil then
+        return
+    end
+    local issue_number = extract_issue_number(noti)
+    if issue_number == nil then
+        return
+    end
+    issues_preview.preview_issue(issue_number)
+end
+
+local function setup_buffer()
+    -- see if we can reuse a buffer that currently exists.
+    if state.buf ~= nil and vim.api.nvim_buf_is_valid(state.buf) then
+        return state.buf
+    else
+        state.buf = vim.api.nvim_create_buf(false, false)
+        if state.buf == 0 then
+            vim.api.nvim_err_writeln("notification_buffer: buffer create failed")
+            return
+        end
+    end
+
+    -- set buf options
+    vim.api.nvim_buf_set_name(state.buf, "github notifications")
+    vim.api.nvim_buf_set_option(state.buf, 'bufhidden', 'hide')
+    vim.api.nvim_buf_set_option(state.buf, 'filetype', 'notifications')
+    vim.api.nvim_buf_set_option(state.buf, 'buftype', 'nofile')
+    vim.api.nvim_buf_set_option(state.buf, 'modifiable', false)
+    vim.api.nvim_buf_set_option(state.buf, 'swapfile', false)
+    vim.api.nvim_buf_set_option(state.buf, 'textwidth', 0)
+    vim.api.nvim_buf_set_option(state.buf, 'wrapmargin', 0)
+    vim.api.nvim_buf_set_option(state.buf, 'ofu', 'v:lua.GH_completion')
+
+    vim.api.nvim_buf_set_keymap(state.buf, 'n', config.config.keymaps.open, "", {callback=M.open_notification})
+    vim.api.nvim_buf_set_keymap(state.buf, 'n', config.config.keymaps.actions, "", {callback=M.notification_actions})
+    vim.api.nvim_buf_set_keymap(state.buf, 'n', config.config.keymaps.details, "", {callback=preview_issue})
+
+    vim.api.nvim_create_autocmd({"BufEnter"}, {
+        buffer = state.buf,
+        callback = require('litee.lib.util.window').set_tree_highlights,
+    })
+    vim.api.nvim_create_autocmd({"BufEnter"}, {
+        buffer = state.buf,
+        callback = _win_settings_on,
+    })
+end
+
+function M.render_notifications(notifications)
+    if state.buf == nil or not vim.api.nvim_buf_is_valid(state.buf) then
+        setup_buffer()
+    end
+    table.sort(notifications, function(a,b)
+        return a["updated_at"] > b["updated_at"]
+    end)
+
+    local marks_to_create = {}
+    local buffer_lines = {}
+
+    local repo = ghcli.get_repo_name_owner()
+
+    -- render notification buffer header
+    table.insert(buffer_lines, string.format("%s %s  Notifications", symbols.top, config.icon_set["Notification"]))
+    table.insert(buffer_lines, string.format("%s %s  Owner: %s", symbols.left, config.icon_set["Account"], repo["owner"]["login"]))
+    table.insert(buffer_lines, string.format("%s %s  Repo: %s", symbols.left, config.icon_set["GitRepo"], repo["name"]))
+    table.insert(buffer_lines, string.format("%s %s  Count: %s", symbols.left, config.icon_set["Number"], #notifications))
+    table.insert(buffer_lines, string.format("%s (open: %s)(notification actions: %s)(preview issue: %s)", symbols.bottom, config.config.keymaps.open, config.config.keymaps.actions, config.config.keymaps.details))
+    -- add an extmark here associated with nil so we don't try to preview when
+    -- cursor is in header.
+    table.insert(marks_to_create, {#buffer_lines-1, nil})
+
+    for _, noti in ipairs(notifications) do
+        local type_ico = config.icon_set["GitIssue"]
+        if noti["subject"]["type"] == "PullRequest" then
+            type_ico = config.icon_set["GitPullRequest"]
+        end
+        local read_ico = config.icon_set["CircleFilled"]
+        if noti["unread"] == false then
+            read_ico = config.icon_set["Circle"]
+        end
+        local issue_number = extract_issue_number(noti)
+        table.insert(buffer_lines, symbols.top)
+        table.insert(buffer_lines, string.format("%s %s  %s  %s %s   %s", symbols.left, read_ico, type_ico, "#"..issue_number, noti["subject"]["title"], noti["reason"]))
+        table.insert(buffer_lines, symbols.bottom)
+        table.insert(marks_to_create, {#buffer_lines-1, noti})
+    end
+
+    -- write all buffer lines to the buffer
+    M.set_modifiable(true)
+    vim.api.nvim_buf_set_lines(state.buf, 0, #buffer_lines, false, buffer_lines)
+    M.set_modifiable(false)
+
+    -- write out all our marks and associate marks with noti objects.
+    for _, m in ipairs(marks_to_create) do
+        local id = vim.api.nvim_buf_set_extmark(
+            state.buf,
+            ns,
+            m[1],
+            0,
+            {}
+        )
+        state.marks_to_notifications[id] = m[2]
+    end
+
+    return state.buf
+end
+
+function M.set_modifiable(bool)
+    if state.buf ~= nil and vim.api.nvim_buf_is_valid(state.buf) then
+        vim.api.nvim_buf_set_option(state.buf, 'modifiable', bool)
+    end
+end
+
+function M.open_notification()
+    local notification = notification_under_cursor()
+    if notification == nil then
+        return
+    end
+    local issue_number = extract_issue_number(notification)
+    if issue_number == nil then
+        return
+    end
+    if notification["subject"]["type"] == "Issue" then
+        issues.open_issue_by_number(issue_number)
+        return
+    end
+    if notification["subject"]["type"] == "PullRequest" then
+        pr.open_pull_by_number(issue_number)
+        return
+    end
+end
+
+local function set_read(notification)
+    local out = ghcli.set_notification_read(notification["id"])
+    if out == nil then
+        lib_notify.notify_popup_with_timeout("Failed to set notification as read.", 7500, "error")
+        return
+    end
+end
+
+local function set_unsubscribed(notification)
+    local out = ghcli.set_notification_ignored(notification["id"])
+    if out == nil then
+        lib_notify.notify_popup_with_timeout("Failed to set unsubscribe from notification.", 7500, "error")
+        return
+    end
+end
+
+function M.notification_actions()
+    local notification = notification_under_cursor()
+    if notification == nil then
+        return
+    end
+    vim.ui.select(
+        {"read", "unsubscribe"},
+        {prompt="Pick a action to perform on this comment: "},
+        function(item, _)
+            if item == nil then
+                return
+            end
+            if item == "read" then
+                set_read(notification)
+            end
+            if item == "unsubscribe" then
+                set_unsubscribed(notification)
+                set_read(notification)
+            end
+            vim.cmd("GHRefreshNotifications")
+        end
+    )
+end
+
+return M

--- a/lua/litee/gh/pr/init.lua
+++ b/lua/litee/gh/pr/init.lua
@@ -129,9 +129,19 @@ local function on_tab_close()
 end
 
 function M.open_pull_by_number(number)
-    if number ~= nil then
+    if s.pull_state ~= nil and s.pull_state ~= nil then
+        vim.ui.select(
+            {"no", "yes"},
+            {prompt = string.format('A pull request is already opened, close it and open pull #%s? ', number)},
+            function(choice)
+                if choice == "yes" then
+                    M.close_pull()
+                    handlers.pr_handler(number, false, vim.schedule_wrap(function () start_refresh_timer() on_tab_close() end ))
+                end
+            end
+        )
+    else
         handlers.pr_handler(number, false, vim.schedule_wrap(function () start_refresh_timer() on_tab_close() end ))
-        return
     end
 end
 
@@ -384,60 +394,62 @@ function M.clean()
 end
 
 -- TODO add other stuff that needs to be done on pr commits
-function M.close_pr_commits(ctx)
-    if ctx == nil then
-         ctx = ui_req_ctx()
-    end
-    if ctx.state == nil or ctx.state["pr_files"] == nil then
+function M.close_pr_commits()
+    if s.pull_state == nil then
         return
     end
-    if ctx.state["pr_files"].win ~= nil then
-        if vim.api.nvim_win_is_valid(ctx.state["pr_files"].win) then
-            vim.api.nvim_win_close(ctx.state["pr_files"].win, true)
+    local state = lib_state.get_state(s.pull_state.tab)
+    if state == nil or state["pr_files"] == nil then
+        return
+    end
+    if state["pr_files"].win ~= nil then
+        if vim.api.nvim_win_is_valid(state["pr_files"].win) then
+            vim.api.nvim_win_close(state["pr_files"].win, true)
         end
     end
-    if ctx.state["pr_files"].buf ~= nil then
-        if vim.api.nvim_buf_is_valid(ctx.state["pr_files"].buf) then
-            vim.api.nvim_buf_delete(ctx.state["pr_files"].buf, {force = true})
+    if state["pr_files"].buf ~= nil then
+        if vim.api.nvim_buf_is_valid(state["pr_files"].buf) then
+            vim.api.nvim_buf_delete(state["pr_files"].buf, {force = true})
         end
     end
-    if ctx.state["pr_files"].tree ~= nil then
-        lib_tree.remove_tree(ctx.state["pr_files"].tree)
+    if state["pr_files"].tree ~= nil then
+        lib_tree.remove_tree(state["pr_files"].tree)
     end
-    lib_state.put_component_state(ctx.tab, "pr_files", nil)
+    lib_state.put_component_state(s.pull_state.tab, "pr_files", nil)
     M.clean()
 end
 
 -- TODO add other stuff that needs to be done on pr reviews
-function M.close_pr_review(ctx)
-    if ctx == nil then
-         ctx = ui_req_ctx()
-    end
-    if ctx.state == nil or ctx.state["pr_review"] == nil then
+function M.close_pr_review()
+    if s.pull_state == nil then
         return
     end
-    if ctx.state["pr_review"].win ~= nil then
-        if vim.api.nvim_win_is_valid(ctx.state["pr_review"].win) then
-            vim.api.nvim_win_close(ctx.state["pr_review"].win, true)
+    local state = lib_state.get_state(s.pull_state.tab)
+    if state == nil or state["pr_review"] == nil then
+        return
+    end
+    if state["pr_review"].win ~= nil then
+        if vim.api.nvim_win_is_valid(state["pr_review"].win) then
+            vim.api.nvim_win_close(state["pr_review"].win, true)
         end
     end
-    if ctx.state["pr_review"].buf ~= nil then
-        if vim.api.nvim_buf_is_valid(ctx.state["pr_review"].buf) then
-            vim.api.nvim_buf_delete(ctx.state["pr_review"].buf, {force = true})
+    if state["pr_review"].buf ~= nil then
+        if vim.api.nvim_buf_is_valid(state["pr_review"].buf) then
+            vim.api.nvim_buf_delete(state["pr_review"].buf, {force = true})
         end
     end
-    if ctx.state["pr_review"].tree ~= nil then
-        lib_tree.remove_tree(ctx.state["pr_review"].tree)
+    if state["pr_review"].tree ~= nil then
+        lib_tree.remove_tree(state["pr_review"].tree)
     end
-    lib_state.put_component_state(ctx.tab, "pr_review", nil)
+    lib_state.put_component_state(s.pull_state.tab, "pr_review", nil)
 end
 
 -- TODO add other stuff that needs to be done on pr close
 function M.close_pull()
-    local ctx = ui_req_ctx()
     if s.pull_state == nil then
         return
     end
+    local state = lib_state.get_state(s.pull_state.tab)
 
     -- put us in a new tab so we can close windows if we don't have one to change
     -- to.
@@ -453,34 +465,35 @@ function M.close_pull()
         vim.cmd("tabnew")
     end
 
+
     -- dump all our state
-    if ctx.state["pr"].win ~= nil then
-        if vim.api.nvim_win_is_valid(ctx.state["pr"].win) then
-            vim.api.nvim_win_close(ctx.state["pr"].win, true)
+    if state["pr"].win ~= nil then
+        if vim.api.nvim_win_is_valid(state["pr"].win) then
+            vim.api.nvim_win_close(state["pr"].win, true)
         end
     end
-    if ctx.state["pr"].buf ~= nil then
-        if vim.api.nvim_buf_is_valid(ctx.state["pr"].buf) then
-            vim.api.nvim_buf_delete(ctx.state["pr"].buf, {force = true})
+    if state["pr"].buf ~= nil then
+        if vim.api.nvim_buf_is_valid(state["pr"].buf) then
+            vim.api.nvim_buf_delete(state["pr"].buf, {force = true})
         end
     end
-    if ctx.state["pr"].tree ~= nil then
-        lib_tree.remove_tree(ctx.state["pr"].tree)
+    if state["pr"].tree ~= nil then
+        lib_tree.remove_tree(state["pr"].tree)
     end
 
     -- pass in our ctx, since we changed tab pages, current tab from ctx wont
     -- work.
-    M.close_pr_commits(ctx)
-    M.close_pr_review(ctx)
+    M.close_pr_commits()
+    M.close_pr_review()
 
     -- rip down our pull request tab
     vim.api.nvim_set_current_tabpage(s.pull_state.tab)
     vim.cmd("tabclose")
 
-    -- nil out the pull state
-    s.pull_state = nil
+    lib_state.put_component_state(s.pull_state.tab, "pr", nil)
 
-    lib_state.put_component_state(ctx.tab, "pr", nil)
+    -- nil our the pull state
+    s.pull_state = nil
 end
 
 

--- a/lua/litee/gh/pr/thread_buffer.lua
+++ b/lua/litee/gh/pr/thread_buffer.lua
@@ -794,8 +794,8 @@ end
 
 -- comment_actions displays a list of actions for a given comment.
 function M.comment_actions()
-    comment = comment_under_cursor()
-    if comment == nil then
+    notification = comment_under_cursor()
+    if notification == nil then
         return
     end
     vim.ui.select(


### PR DESCRIPTION
This feature introduces the "GHNotifications" command.

This command will open a new buffer which lists the notifications for
the given repository Neovim is opened to.

From there you can open PRs and issues which the notifications
reference.

By setting a notification as "read" it will be removed from the buffer
view. By setting it to "unsubscribed" it will be removed and any further
non-mention comments will be ignored.
