### PR TITLE
fix: loosen up issue number regex

### DIFF
--- a/lua/litee/gh/issues/init.lua
+++ b/lua/litee/gh/issues/init.lua
@@ -10,7 +10,7 @@ local M = {}
 
 local function extract_issue_under_cursor()
     local current_word = vim.fn.expand('<cWORD>')
-    local issue_number = current_word:match('^#[0-9]+')
+    local issue_number = current_word:match('#[0-9]+')
 
     if issue_number == nil then
       return nil


### PR DESCRIPTION
This is a follow up for #55.

Asserting the start of the line gets in the way of matching issue ids in
the issue buffer, which uses a border right next to the issue number.

For example, the following comment in `GHOpenIssue 55`:

```
│#53
```