### PR TITLE
fix: check for args existence before accessing it

### DIFF
--- a/lua/litee/gh/pr/init.lua
+++ b/lua/litee/gh/pr/init.lua
@@ -294,7 +294,7 @@ end
 -- once picked a new tab is created and the the pr details and commits are
 -- populated in a tree for this tab.
 function M.open_pull(args)
-    if args["args"] ~= "" then
+    if args and args["args"] ~= "" then
         M.open_pull_by_number(args["args"])
         return
     end


### PR DESCRIPTION
Calling `:GH` and selecting `GHOpenPR` results in an error because the `open_pull(args)` function in `litee/gh/pr/init.lua` is called with null arguments. This PR adds a check to avoid the error.