### PR TITLE
Use highlights as message separators

### DIFF
--- a/doc/gh-nvm.txt
+++ b/doc/gh-nvm.txt
@@ -420,3 +420,23 @@ M.config = {
         toggle_unread = "u"
     },
 }
+
+====================================================================================
+Highlights                                                           *gh-highlights*
+
+The following highlights are defined and can be declared by themers. If they
+are not declared GH.nvim will set a default which is also listed below.
+
+Highlight               Purpose                                 Default
+*******************************************************************************
+
+GHThreadSep             The fg and bg highlight used for a      Pmenu 
+                        threaded message.
+
+GHThreadSepAlt          Similar to above but can be used as     Pmenu
+                        an alternating color between messages 
+                        in a threaded message. For example in 
+                        a threaded message with 3 messages the 
+                        first will use the GHThreadSep highlight, 
+                        second will use GHThreadSepAlt and third 
+                        will use GHThreadSep.

--- a/lua/litee/gh/config.lua
+++ b/lua/litee/gh/config.lua
@@ -17,6 +17,15 @@ M.config = {
     -- background refresh timer interval in milliseconds. defaults to five
     -- minutes.
     refresh_interval = 300000,
+    -- list of highlights to be used within the UI.
+    highlights = {
+        -- the following highlights will highlight threaded messages in conversation
+        -- buffers. 
+        -- you can alternate between two highlights if desired by setting these
+        -- to different highlights.
+        thread_separator = "GHThreadSep",
+        thread_separator_alt = "GHThreadSepAlt"
+    },
     -- defines keymaps in gh.nvim buffers.
     keymaps = {
         -- when inside a gh.nvim panel, this key will open a node if it has

--- a/lua/litee/gh/init.lua
+++ b/lua/litee/gh/init.lua
@@ -204,6 +204,15 @@ local function register_git_buffer_completion()
     })
 end
 
+function register_default_highlights()
+    if vim.fn.hlexists("GHThreadSep") == 0 then
+        vim.cmd("hi link GHThreadSep Pmenu")
+    end
+    if vim.fn.hlexists("GHThreadSepAlt") == 0 then
+        vim.cmd("hi link GHThreadSepAlt Pmenu")
+    end
+end
+
 function M.setup(user_config)
     if not pcall(require, "litee.lib") then
         lib_notify.notify_popup_with_timeout("Cannot start litee-gh without the litee.lib library.", 1750, "error")
@@ -230,6 +239,7 @@ function M.setup(user_config)
     register_pr_component()
     register_pr_files_component()
     register_pr_review_component()
+    register_default_highlights()
     commands.setup()
 end
 


### PR DESCRIPTION
This PR moves away from using utf-8 icons as message separators and will use highlights instead.

This is more useful since wrapping works way better. There are no icons which can get wrapped incorrectly and make the output look screwed up. 

Two new highlights are added "GHThreadSep" and "GHThreadSepAlt" which allow for alternating message separators. 

Here is a screenshot of a message thread after this PR.

![image](https://user-images.githubusercontent.com/5642902/183316801-4b0dda12-3f51-42a4-90a3-d2dc01227a2b.png)

This PR sets both new highlights to a default of "Pmenu" if they are not defined. 