### PR TITLE
feat,useability: introduce debug buffer for cli interactions

### DIFF
--- a/doc/gh-nvm.txt
+++ b/doc/gh-nvm.txt
@@ -18,6 +18,7 @@ CONTENTS                                                         *litee-contents
   4     Commands......................................|gh-commands|
   6     Config........................................|gh-config|
   7     Highlights....................................|gh-highlights|
+  7     Debugging.....................................|gh-debugging|
 
 ====================================================================================
 INTRODUCTION                                                              *gh-intro*
@@ -361,6 +362,9 @@ local commands = {
     -- Open a UI displaying all unread notifications for the repo gh.nvim is opened
     -- to.
     {name = "GHNotifications", callback = noti.open_notifications, opts = {}},
+    -- When config["debug_logging"] is set to true, this command will open a buffer
+    -- holding all git and gh cli invocations and their outputs.
+    {name = "GHOpenDebugBuffer", callback = debug.open_debug_buffer, opts = {}},
 }
 
 ====================================================================================
@@ -385,6 +389,18 @@ M.config = {
     -- background refresh timer interval in milliseconds. defaults to five
     -- minutes.
     refresh_interval = 300000,
+    -- list of highlights to be used within the UI.
+    highlights = {
+        -- the following highlights will highlight threaded messages in conversation
+        -- buffers. 
+        -- you can alternate between two highlights if desired by setting these
+        -- to different highlights.
+        thread_separator = "GHThreadSep",
+        thread_separator_alt = "GHThreadSepAlt"
+    },
+    -- log all git and gh cli actions to a buffer.
+    -- the buffer can be opened with "GHOpenDebugBuffer" when this is set to true.
+    debug_logging = false,
     -- defines keymaps in gh.nvim buffers.
     keymaps = {
         -- when inside a gh.nvim panel, this key will open a node if it has
@@ -440,3 +456,27 @@ GHThreadSepAlt          Similar to above but can be used as     Pmenu
                         first will use the GHThreadSep highlight, 
                         second will use GHThreadSepAlt and third 
                         will use GHThreadSep.
+
+====================================================================================
+Debugging                                                             *gh-debugging*
+
+It is possible to output all `gh` and `git` cli calls and their output into a 
+debug buffer. 
+
+To do this you must set the `debug_logging` field in your user config to `true`.
+When this is enabled you can use the `GHOpenDebugBuffer` which will open a buffer
+full of cli debug information in a new tab.
+
+The format of a log message is:
+
+[{level}] [{cli}] cmd: {command line} out:\n {returned output} 
+
+Where:
+
+{level}             - "info", "warning", "error"
+{cli}               - "gh" or "git" (currently)
+{command line}      - the exact cli command ran
+{returned output}   - output of the command, if the command outputs json its 
+                      typical that it will be converted to a lua table and ran
+                      through vim.inspect(), pretty printing the output.
+

--- a/doc/tags
+++ b/doc/tags
@@ -1,5 +1,6 @@
 gh-commands	gh-nvm.txt	/*gh-commands*
 gh-config	gh-nvm.txt	/*gh-config*
+gh-highlights	gh-nvm.txt	/*gh-highlights*
 gh-intro	gh-nvm.txt	/*gh-intro*
 gh-usage	gh-nvm.txt	/*gh-usage*
 gh.nvim	gh-nvm.txt	/*gh.nvim*

--- a/lua/litee/gh/commands.lua
+++ b/lua/litee/gh/commands.lua
@@ -3,6 +3,7 @@ local dv = require('litee.gh.pr.diff_view')
 local noti = require('litee.gh.notifications')
 local pr_handlers = require('litee.gh.pr.handlers')
 local issues = require('litee.gh.issues')
+local debug  = require('litee.gh.debug')
 
 local M = {}
 
@@ -87,6 +88,9 @@ local commands = {
     -- Open a UI displaying all unread notifications for the repo gh.nvim is opened
     -- to.
     {name = "GHNotifications", callback = noti.open_notifications, opts = {}},
+    -- When config["debug_logging"] is set to true, this command will open a buffer
+    -- holding all git and gh cli invocations and their outputs.
+    {name = "GHOpenDebugBuffer", callback = debug.open_debug_buffer, opts = {}},
 }
 
 function M.command_select()

--- a/lua/litee/gh/config.lua
+++ b/lua/litee/gh/config.lua
@@ -26,6 +26,9 @@ M.config = {
         thread_separator = "GHThreadSep",
         thread_separator_alt = "GHThreadSepAlt"
     },
+    -- log all git and gh cli actions to a buffer.
+    -- the buffer can be opened with "GHOpenDebugBuffer".
+    debug_logging = false,
     -- defines keymaps in gh.nvim buffers.
     keymaps = {
         -- when inside a gh.nvim panel, this key will open a node if it has

--- a/lua/litee/gh/debug.lua
+++ b/lua/litee/gh/debug.lua
@@ -1,0 +1,45 @@
+local c = require('litee.gh.config')
+
+local M = {}
+
+local level_to_hl = {
+    error = "ErrorMsg",
+    info  = "Normal",
+    warning = "WarningMsg"
+}
+
+local debug_buffer = (function()
+    if not c.config.debug_logging then
+        return
+    end
+    local buf = vim.api.nvim_create_buf(false, false)
+    vim.api.nvim_buf_set_name(buf, "gh.nvim://debug_buffer")
+    vim.api.nvim_buf_set_option(buf, 'buftype', 'nofile')
+    return buf
+end)()
+
+function M.open_debug_buffer()
+    if not c.config.debug_logging then
+        return
+    end
+    vim.cmd("tabnew")
+    vim.api.nvim_win_set_buf(0, debug_buffer)
+end
+
+-- log will no-op if debug_logging is not set, or print a debug message to
+-- the status line if it is.
+function M.log(msg, level)
+    vim.schedule(function()
+        local msg_split = vim.fn.split(msg, "\n")
+        if level_to_hl[level] == nil then
+            return
+        end
+        msg_split[1] = "[" .. level .. "] " .. msg_split[1]
+        if c.config.debug_logging then
+           local lc = vim.api.nvim_buf_line_count(debug_buffer)
+           vim.api.nvim_buf_set_lines(debug_buffer, lc-1, (lc+#msg_split)-1, false, msg_split)
+        end
+    end)
+end
+
+return M

--- a/lua/litee/gh/gitcli/init.lua
+++ b/lua/litee/gh/gitcli/init.lua
@@ -1,8 +1,12 @@
+local debug = require('litee.gh.debug')
+
 local function git_exec(cmd)
     local out = vim.fn.system(cmd)
     if vim.v.shell_error ~= 0 then
+        debug.log("[git] cmd: " .. cmd .. " out:\n" .. vim.inspect(out), "error")
         return nil
     end
+    debug.log("[git] cmd: " .. cmd .. " out:\n" .. vim.inspect(out), "info")
     return out
 end
 


### PR DESCRIPTION
this commit adds a new config flag "debug_logging" and a new command
"GHOpenDebugBuffer".

when `debug_logging` is flipped to `true` in the user config passed to
setup(), all CLI interactions will be outputted into a debug buffer.

this debug buffer can be opened with the command "GHOpenDebugBuffer".
see doc/gh-nvim.txt for more details.