### PR TITLE
useability: allow opening of prs with deleted branches

### DIFF
--- a/lua/litee/gh/gitcli/init.lua
+++ b/lua/litee/gh/gitcli/init.lua
@@ -106,6 +106,20 @@ function M.remote_exists(remote_url)
     return true, remote
 end
 
+function M.remote_branch_exists(remote_url, branch)
+    local cmd = [[git ls-remote --heads ]] .. remote_url .. " " .. branch
+    local out = git_exec(cmd)
+    if out == nil then
+        return nil
+    end
+
+    if #out == 0 then
+        return false
+    else
+        return true
+    end
+end
+
 function M.git_show_and_write(commit, file, write_to)
     local cmd = string.format([[git show %s:%s > %s]], commit, file, write_to)
     local out = git_exec(cmd)

--- a/lua/litee/gh/pr/handlers.lua
+++ b/lua/litee/gh/pr/handlers.lua
@@ -68,11 +68,21 @@ function M.ui_handler(refresh, on_load_ui)
         else
             remote_name = remote
         end
-        -- fetch the remote branch so the commits under review are locally accessible.
-        local out = gitcli.fetch(remote_name, head_branch)
-        if out == nil then
-            lib_notify.notify_popup_with_timeout("Failed to fetch remote branch.", 7500, "error")
+
+        local remote_branch_exists = gitcli.remote_branch_exists(remote_url, head_branch)
+        if remote_branch_exists == nil then
+            lib_notify.notify_popup_with_timeout("Failed to determine if remote branch exists", 7500, "error")
             return
+        end
+
+        if remote_branch_exists then
+            local out = gitcli.fetch(remote_name, head_branch)
+            if out == nil then
+                lib_notify.notify_popup_with_timeout("Failed to fetch remote branch.", 7500, "error")
+                return
+            end
+        else
+            lib_notify.notify_popup_with_timeout("Remote branch no longer exists, cannot fetch it. PR will be opened but certain commits may not be available for checkout.", 7500, "warning")
         end
     end
 


### PR DESCRIPTION
when a branch is deleted, usually, the commits are still available
within the remote repository.

this commit allows a pr where the upstream branch has been deleted to be
opened, and explored against the GH API like normal.

a warning message is displayed when opening a pr where the upstream
branch is deleted.

Signed-off-by: ldelossa <louis.delos@gmail.com>