### PR TITLE
fix: fix review thread conflicts

### DIFF
--- a/lua/litee/gh/ghcli/graphql.lua
+++ b/lua/litee/gh/ghcli/graphql.lua
@@ -15,9 +15,9 @@ mutation ($pull: ID!, $review: ID!, $commit: GitObjectID!, $body: String!, $repl
 ]]
 
 M.create_comment_review = [[
-mutation ($pull: ID!, $review: ID!, $body: String!, $path: String!, $line: Int!, $side: DiffSide!) {
-  addPullRequestReviewThread(
-    input: {pullRequestId: $pull, pullRequestReviewId: $review, body: $body, path: $path, line: $line, side: $side}
+mutation ($pull: ID!, $review: ID!, $body: String!, $path: String!, $pos: Int!, $sha: GitObjectID!) {
+  addPullRequestReviewComment(
+    input: {pullRequestId: $pull, pullRequestReviewId: $review, body: $body, path: $path, position: $pos, commitOID: $sha}
   ) {
     clientMutationId
   }
@@ -201,6 +201,7 @@ query ($name: String!, $owner: String!, $pull_number: Int!) {
                   createdAt
                   path
                   position
+                  originalPosition
                   publishedAt
                   replyTo {
                     id
@@ -209,6 +210,17 @@ query ($name: String!, $owner: String!, $pull_number: Int!) {
                     id
                   }
                   commit {
+                    oid
+                    parents(first: 1) {
+                      edges {
+                        node {
+                          id
+                          oid
+                        }
+                      }
+                    }
+                  }
+                  originalCommit {
                     oid
                     parents(first: 1) {
                       edges {

--- a/lua/litee/gh/ghcli/init.lua
+++ b/lua/litee/gh/ghcli/init.lua
@@ -575,14 +575,14 @@ end
 
 -- this is a graphql query so pass use the node_id for each argument that wants
 -- and id.
-function M.create_comment_review(pull_id, review_id, body, path, line, side)
-    local cmd = string.format([[gh api graphql -F pull="%s" -F review="%s" -F body=%s -F path="%s" -F line=%d  -F side=%s -f query='%s']],
+function M.create_comment_review(pull_id, review_id, body, path, pos, sha)
+    local cmd = string.format([[gh api graphql -F pull="%s" -F review="%s" -F body=%s -F path="%s" -F pos=%d -F sha="%s" -f query='%s']],
         pull_id,
         review_id,
         body,
         path,
-        line,
-        side,
+        pos,
+        sha,
         graphql.create_comment_review
     )
     local resp = gh_exec(cmd)


### PR DESCRIPTION
previous to this commit gh.nvim did not understand that a comment can
track its original commit sha

without this, it could not decipher which comments belonged to which
commits and would overrlay comments over multiple commits.

with these changes will now only display comments on a commit in the
commit tree view, checkout the commit and open the correct files when
using the Conversations: tab, and correctly sync review threads to their
commits during review.

additionally, a few UI elements have changed. the Conversations: tab in
the pr details tree now shows the commit a threaded conversation belongs
to. Also, an asterick is used in the Commits: tree now to indicate which
commit gh.nvim has currently checked out.

fixes: #47

Signed-off-by: Louis DeLosSantos <louis.delos@gmail.com>