### PR TITLE
fix: perform source file matching for comment linking

### DIFF
--- a/lua/litee/gh/pr/init.lua
+++ b/lua/litee/gh/pr/init.lua
@@ -864,12 +864,8 @@ local function open_pr_node(ctx, node)
         -- set refresh to true so diff_view is not opened, we'll open it 
         -- more specifically below
         handlers.commits_handler(sha, true)
-
         local commit = s.pull_state.commits_by_sha[sha]
         local file = s.pull_state.files_by_name[node.thread["path"]]
-        if file == nil then
-            return
-        end
         diff_view.open_diffsplit(commit, file, node.thread, true)
     end
     if node.comment ~= nil then
@@ -882,9 +878,6 @@ local function open_pr_node(ctx, node)
 
         local commit = s.pull_state.commits_by_sha[sha]
         local file = s.pull_state.files_by_name[thread.thread["path"]]
-        if file == nil then
-            return
-        end
         diff_view.open_diffsplit(commit, file, thread.thread, true)
     end
     if node.review ~= nil then
@@ -972,9 +965,6 @@ local function open_pr_review_node(ctx, node)
 
         local commit = s.pull_state.commits_by_sha[s.pull_state.head]
         local file = s.pull_state.files_by_name[node.thread["path"]]
-        if file == nil then
-            return
-        end
         diff_view.open_diffsplit(commit, file, node.thread)
     end
     if node.comment ~= nil then
@@ -987,9 +977,6 @@ local function open_pr_review_node(ctx, node)
         local thread = s.pull_state.review_threads_by_id[node.comment["thread_id"]]
         local commit = s.pull_state.commits_by_sha[s.pull_state.head]
         local file = s.pull_state.files_by_name[thread.thread["path"]]
-        if file == nil then
-            return
-        end
         diff_view.open_diffsplit(commit, file, thread.thread)
     end
 end

--- a/lua/litee/gh/pr/thread_buffer.lua
+++ b/lua/litee/gh/pr/thread_buffer.lua
@@ -344,9 +344,9 @@ local function resolve_thread_line(thread, original_commit)
     return line
 end
 
-local function write_preview(thread, buffer_lines, lines_to_highlight, hi)
+local function write_preview(thread, buffer_lines, lines_to_highlight, hi, line_nr)
     local root_comment = thread.children[1].comment
-    local comment_line = resolve_thread_line(thread.thread, root_comment["originalCommit"]["oid"]) + 1
+    local comment_line = line_nr + 1
     local lines = vim.split(root_comment["diffHunk"], "\n")
     table.insert(buffer_lines, "")
     table.insert(lines_to_highlight, {#buffer_lines, hi})
@@ -388,7 +388,7 @@ end
 -- previously writen text.
 --
 -- this method is intended to work as a 'refresh' method as well.
-function M.render_thread(thread_id, n_of, displayed_thread, side)
+function M.render_thread(thread_id, line_nr, n_of, displayed_thread, side)
     setup_buffer(thread_id)
 
     local restore = restore_thread(thread_id, displayed_thread)
@@ -457,7 +457,7 @@ function M.render_thread(thread_id, n_of, displayed_thread, side)
     table.insert(buffer_lines, string.format("%s  Last Updated: %s",  config.icon_set["Calendar"], root_comment.comment["updatedAt"]))
     table.insert(lines_to_highlight, {#buffer_lines, hi})
     -- preview in header
-    write_preview(thread, buffer_lines, lines_to_highlight, hi)
+    write_preview(thread, buffer_lines, lines_to_highlight, hi, line_nr)
     table.insert(buffer_lines, "")
     table.insert(lines_to_highlight, {#buffer_lines, hi})
     table.insert(buffer_lines, string.format("(submit: %s)(comment actions: %s)(un/resolve: %s)", config.config.keymaps.submit_comment, config.config.keymaps.actions, config.config.keymaps.resolve_thread))

--- a/lua/litee/gh/pr/thread_buffer.lua
+++ b/lua/litee/gh/pr/thread_buffer.lua
@@ -358,19 +358,32 @@ local function write_preview(thread, buffer_lines, lines_to_highlight, hi, line_
         table.insert(tmp, lines[i])
     end
     if #tmp > 0 then
-        comment_line = comment_line - #tmp
+        local prev_symbol = ""
+        comment_line = (comment_line - #tmp)-1
         for i = #tmp, 1, -1 do
             local l = tmp[i]
-            local buf_line = string.format("%d ▏%s", comment_line, l)
-            table.insert(buffer_lines, buf_line)
             if string.sub(l,1,1) == "+" then
+                if prev_symbol ~= "-" then
+                    comment_line = comment_line + 1
+                end
+                l = string.sub(l, 2, -1)
+                local buf_line = string.format("%d + ▏ %s", comment_line, l)
+                table.insert(buffer_lines, buf_line)
                 table.insert(lines_to_highlight, {#buffer_lines, "DiffAdd"})
+                prev_symbol = "+"
             elseif string.sub(l,1,1) == "-" then
+                comment_line = comment_line + 1
+                l = string.sub(l, 2, -1)
+                local buf_line = string.format("%d - ▏ %s", comment_line, l)
+                table.insert(buffer_lines, buf_line)
                 table.insert(lines_to_highlight, {#buffer_lines, "DiffDelete"})
+                prev_symbol = "-"
             else
+                comment_line = comment_line + 1
+                local buf_line = string.format("%d   ▏ %s", comment_line, l)
+                table.insert(buffer_lines, buf_line)
                 table.insert(lines_to_highlight, {#buffer_lines, hi})
             end
-            comment_line = comment_line + 1
         end
     end
 end


### PR DESCRIPTION
this commit removes any comment-to-commit-sha checking and instead
relies on matching the source code line the comment references to the
actual lines in a vim buffer.

Signed-off-by: Louis DeLosSantos <louis.delos@gmail.com>