### PR TITLE
When starting a review: creating a single line comment is broken

### DIFF
--- a/lua/litee/gh/ghcli/graphql.lua
+++ b/lua/litee/gh/ghcli/graphql.lua
@@ -15,9 +15,9 @@ mutation ($pull: ID!, $review: ID!, $commit: GitObjectID!, $body: String!, $repl
 ]]
 
 M.create_comment_review = [[
-mutation ($pull: ID!, $review: ID!, $body: String!, $path: String!, $pos: Int!, $sha: GitObjectID!) {
-  addPullRequestReviewComment(
-    input: {pullRequestId: $pull, pullRequestReviewId: $review, body: $body, path: $path, position: $pos, commitOID: $sha}
+mutation ($pull: ID!, $review: ID!, $body: String!, $path: String!, $line: Int!, $side: DiffSide!) {
+  addPullRequestReviewThread(
+    input: {pullRequestId: $pull, pullRequestReviewId: $review, body: $body, path: $path, line: $line, side: $side}
   ) {
     clientMutationId
   }

--- a/lua/litee/gh/ghcli/init.lua
+++ b/lua/litee/gh/ghcli/init.lua
@@ -575,14 +575,14 @@ end
 
 -- this is a graphql query so pass use the node_id for each argument that wants
 -- and id.
-function M.create_comment_review(pull_id, review_id, body, path, pos, sha)
-    local cmd = string.format([[gh api graphql -F pull="%s" -F review="%s" -F body=%s -F path="%s" -F pos=%d -F sha="%s" -f query='%s']],
+function M.create_comment_review(pull_id, review_id, body, path, line, side)
+    local cmd = string.format([[gh api graphql -F pull="%s" -F review="%s" -F body=%s -F path="%s" -F line=%d -F side=%s -f query='%s']],
         pull_id,
         review_id,
         body,
         path,
-        pos,
-        sha,
+        line,
+        side,
         graphql.create_comment_review
     )
     local resp = gh_exec(cmd)

--- a/lua/litee/gh/pr/thread_buffer.lua
+++ b/lua/litee/gh/pr/thread_buffer.lua
@@ -737,12 +737,6 @@ local function create(body, details)
     else
     -- create comment within the review
        if details.line == details.end_line then
-           local commit = nil
-           if s.pull_state.last_opened_commit ~= nil then
-               commit = s.pull_state.last_opened_commit
-           else
-               commit = s.pull_state.head
-           end
            local out = ghcli.create_comment_review(
                s.pull_state.pr_raw["node_id"],
                s.pull_state.review["node_id"],

--- a/lua/litee/gh/pr/thread_buffer.lua
+++ b/lua/litee/gh/pr/thread_buffer.lua
@@ -749,7 +749,7 @@ local function create(body, details)
                body,
                details.path,
                details.line,
-               commit
+               details.side
            )
            if out == nil then
                lib_notify.notify_popup_with_timeout("Failed to create new comment.", 7500, "error")


### PR DESCRIPTION
This fixes the single line comment during a review. It seems like on 2023-10-01 GH deprecated the `possiton` and `path` which is what was used to create a comment during a started review. It seems like [here](https://docs.github.com/en/graphql/reference/input-objects#addpullrequestreviewcommentinput) states to use `addPullRequestReviewThread` instead.

This addresses https://github.com/ldelossa/gh.nvim/issues/76 and possibly https://github.com/ldelossa/gh.nvim/issues/86