### PR TITLE
Use base sha from pr data in file diff view

### DIFF
--- a/lua/litee/gh/pr/diff_view.lua
+++ b/lua/litee/gh/pr/diff_view.lua
@@ -433,7 +433,7 @@ function M.open_diffsplit(commit, file, thread, compare_base)
     -- write the old version of the file to /tmp/ and diff it
     local parent_commit = nil
     if compare_base then
-        parent_commit = s.pull_state.commits[1]["parents"][1]["sha"]
+        parent_commit = s.pull_state.pr_raw.base.sha
     else
         parent_commit = commit["parents"][1]["sha"]
     end


### PR DESCRIPTION
Currently, in diff files, we use the parent commit of the first commit of the PR as the base ref for the diff view by files (!= commit).

When a PR is opened targeting a base branch (main), for a branch that is currently rebased on the target branch, the current diff for changed file is correct.

However, if the workflow is not to rebase on the base branch, but to merge the base branch into the PR branch, we see changes that are not included in the PR in the diff, because we are comparing with an old ref. This is because the parent commit of the first commit is an older commit of the base branch, so any change added to the base branch and merged into the target branch will be considered as part of the diff.

To mirror the diff we see on the web UI, using the sha from the pr data fixes this.

Here is a minimal repro of the issue that prompted this PR: https://github.com/GuillaumeLagrange/neoconf-repro/pull/2
