### PR TITLE
Display checkmark icon in PR files if file is marked as viewed

### DIFF
--- a/doc/gh-nvm.txt
+++ b/doc/gh-nvm.txt
@@ -330,6 +330,8 @@ local commands = {
     {name = "GHNextThread", callback = dv.next_thread, opts = {}},
     -- when cursor is on a line which can be commented in a diff view, create a comment
     {name = "GHCreateThread", callback = dv.create_comment, opts = {range=true}},
+    -- toggle viewed state of the file being diffed
+    {name = "GHToggleViewed", callback = dv.toggle_file_viewed, opts = {}},
     -- close a PR and cleanup any state associated with it (happens on tab and neovim close as well)
     {name = "GHClosePR", callback = pr.close_pull, opts = {}},
     -- close the Commit panel

--- a/lua/litee/gh/commands.lua
+++ b/lua/litee/gh/commands.lua
@@ -56,6 +56,8 @@ local commands = {
     {name = "GHNextThread", callback = dv.next_thread, opts = {}},
     -- when cursor is on a line which can be commented in a diff view, create a comment
     {name = "GHCreateThread", callback = dv.create_comment, opts = {range=true}},
+    -- toggle viewed state of the file being diffed
+    {name = "GHToggleViewed", callback = dv.toggle_file_viewed, opts = {}},
     -- close a PR and cleanup any state associated with it (happens on tab and neovim close as well)
     {name = "GHClosePR", callback = pr.close_pull, opts = {}},
     -- close the Commit panel

--- a/lua/litee/gh/ghcli/graphql.lua
+++ b/lua/litee/gh/ghcli/graphql.lua
@@ -629,4 +629,49 @@ query ($name: String!, $owner: String!, $pull_number: Int!) {
     }
 }
 ]]
+
+M.pull_files_viewed_states_query = [[
+query($name: String!, $owner: String!, $pull_number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pull_number) {
+      id
+      files(first: 50) {
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        edges {
+          node {
+            path
+            viewerViewedState
+          }
+        }
+      }
+    }
+  }
+}
+]]
+
+M.pull_files_viewed_states_query_cursor = [[
+query($name: String!, $owner: String!, $pull_number: Int!, $cursor: String!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pull_number) {
+      id
+      files(first: 50, after: $cursor) {
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        edges {
+          node {
+            path
+            viewerViewedState
+          }
+        }
+      }
+    }
+  }
+}
+]]
+
 return M

--- a/lua/litee/gh/ghcli/graphql.lua
+++ b/lua/litee/gh/ghcli/graphql.lua
@@ -674,4 +674,20 @@ query($name: String!, $owner: String!, $pull_number: Int!, $cursor: String!) {
 }
 ]]
 
+M.mark_file_as_viewed = [[
+mutation ($pull_request_id: ID!, $path: String!) {
+	markFileAsViewed( input: {pullRequestId: $pull_request_id, path: $path}) {
+	  clientMutationId
+	}
+}
+]]
+
+M.mark_file_as_unviewed = [[
+mutation ($pull_request_id: ID!, $path: String!) {
+	unmarkFileAsViewed( input: {pullRequestId: $pull_request_id, path: $path}) {
+	  clientMutationId
+	}
+}
+]]
+
 return M

--- a/lua/litee/gh/ghcli/init.lua
+++ b/lua/litee/gh/ghcli/init.lua
@@ -518,6 +518,36 @@ function M.get_pull_files_viewed_state_async(pull_number, on_read)
     async_request(args, paginate)
 end
 
+function M.mark_file_as_viewed(pull_request_id, path, on_read)
+    local args = {
+        "api",
+        "graphql",
+        "-F",
+        string.format("pull_request_id=%s", pull_request_id),
+        "-F",
+        string.format("path=%s", path),
+        "-f",
+        string.format("query=%s", graphql.mark_file_as_viewed),
+    }
+
+    async_request(args, on_read)
+end
+
+function M.mark_file_as_unviewed(pull_request_id, path, on_read)
+    local args = {
+        "api",
+        "graphql",
+        "-F",
+        string.format("pull_request_id=%s", pull_request_id),
+        "-F",
+        string.format("path=%s", path),
+        "-f",
+        string.format("query=%s", graphql.mark_file_as_unviewed),
+    }
+
+    async_request(args, on_read)
+end
+
 -- because graphql really sucks, write a special paginated function for this.
 function M.get_review_threads_async_paginated(pull_number, on_read)
     local args = {

--- a/lua/litee/gh/pr/buffer.lua
+++ b/lua/litee/gh/pr/buffer.lua
@@ -18,13 +18,13 @@ function M.setup_buffer(name, buf, tab, node_handler, details_handler)
 
     -- set buf options
     vim.api.nvim_buf_set_name(buf, name .. ":" .. tab)
-    vim.api.nvim_buf_set_option(buf, 'bufhidden', 'hide')
-    vim.api.nvim_buf_set_option(buf, 'filetype', 'pr')
-    vim.api.nvim_buf_set_option(buf, 'buftype', 'nofile')
-    vim.api.nvim_buf_set_option(buf, 'modifiable', false)
-    vim.api.nvim_buf_set_option(buf, 'swapfile', false)
-    vim.api.nvim_buf_set_option(buf, 'textwidth', 0)
-    vim.api.nvim_buf_set_option(buf, 'wrapmargin', 0)
+    vim.api.nvim_set_option_value('bufhidden', 'hide', { buf = buf })
+    vim.api.nvim_set_option_value('filetype', 'pr', { buf = buf })
+    vim.api.nvim_set_option_value('buftype', 'nofile', { buf = buf })
+    vim.api.nvim_set_option_value('modifiable', false, { buf = buf })
+    vim.api.nvim_set_option_value('swapfile', false, { buf = buf })
+    vim.api.nvim_set_option_value('textwidth', 0, { buf = buf })
+    vim.api.nvim_set_option_value('wrapmargin', 0, { buf = buf })
 
     -- set buffer local keymaps
     if not config.disable_keymaps then

--- a/lua/litee/gh/pr/files_changed.lua
+++ b/lua/litee/gh/pr/files_changed.lua
@@ -89,7 +89,7 @@ function M.build_files_changed_tree(files, depth, prev_tree)
         return dir
     end
 
-    for p, file in pairs(files) do
+    for _, file in pairs(files) do
         local dir = lib_path.parent_dir(file["filename"])
         local dir_node = recursive_mkdir(dir)
 

--- a/lua/litee/gh/pr/marshal.lua
+++ b/lua/litee/gh/pr/marshal.lua
@@ -143,7 +143,11 @@ local function marshal_file_node(node)
     if node.file["state"] ~= vim.NIL then
         detail = node.file["status"]
     end
-    icon = config.icon_set["File"]
+    if node.file["viewed_state"] == "VIEWED" then
+        icon = config.icon_set["Check"]
+    else
+        icon = config.icon_set["File"]
+    end
 
     return name, detail, icon
 end

--- a/lua/litee/gh/pr/state.lua
+++ b/lua/litee/gh/pr/state.lua
@@ -160,7 +160,7 @@ function M.remove_notification(id, cb)
 end
 
 local spinner_state = -1
-function spinner()
+local function spinner()
     local spinners = {[0] = "⣾", [1] = "⣽", [2] = "⣻", [3] = "⢿", [4] = "⡿", [5] = "⣟", [6] = "⣯", [7] = "⣷"}
     spinner_state = spinner_state + 1
     return spinners[spinner_state%8]


### PR DESCRIPTION
This pr queries the [pull request file viewed state](https://docs.github.com/en/graphql/reference/objects#pullrequestchangedfile) from github's graphql api, and displays a small check mark is the file has been marked as viewed.

![image](https://github.com/ldelossa/gh.nvim/assets/19265358/4b9a4029-0102-4989-b1a4-ae93b2ad8bc5)


Resolves #98 
