### PR TITLE
Fix review comment threads for pending reviews

### DIFF
--- a/lua/litee/gh/ghcli/init.lua
+++ b/lua/litee/gh/ghcli/init.lua
@@ -830,7 +830,7 @@ function M.create_comment_review(pull_id, review_id, body, path, line, side)
       "-F",
       string.format("line=%d", line),
       "-F",
-      string.format("side=%s", side)
+      string.format("side=%s", side),
       "-f",
       string.format("query=%s", graphql.create_comment_review)
     }
@@ -860,9 +860,9 @@ function M.create_comment_review_multiline(pull_id, review_id, body, path, start
       "-F",
       string.format("line=%d", line),
       "-F",
-      string.format("start_side=%s", side)
+      string.format("start_side=%s", side),
       "-F",
-      string.format("side=%s", side)
+      string.format("side=%s", side),
       "-f",
       string.format("query=%s", graphql.create_comment_review_multiline)
     }


### PR DESCRIPTION
Commit d6afb4f61dc4 ("gh_exec uses extra args like async_request")
inadvertently introduced some malformed GitHub CLI commands by merging
multiple field parameters together. This would result in the following
runtime error when attempting to add a comment to a pending PR review:

```
E5108: Error executing lua: .../gh.nvim/lua/litee/gh/ghcli/init.lua:834: attempt to call a string value
stack traceback:
        .../gh.nvim/lua/litee/gh/ghcli/init.lua:834: in function 'create_comment_review'
        .../gh.nvim/lua/litee/gh/pr/thread_buffer.lua:740: in function 'create'
        .../gh.nvim/lua/litee/gh/pr/thread_buffer.lua:842: in function <...ts/.vim/bundle/gh.nvim/lua/litee/gh/pr/thread_buffer.lua:823>
```

Fix it by introducing the necessary commas to separate the fields.

Fixes: d6afb4f61dc4 ("gh_exec uses extra args like async_request")
Fixes: #115 