### PR TITLE
Fix posting thread reply comments

### DIFF
--- a/lua/litee/gh/ghcli/init.lua
+++ b/lua/litee/gh/ghcli/init.lua
@@ -907,7 +907,7 @@ function M.reply_comment_review(pull_id, review_id, commit_sha, body, reply_id)
       "-F",
       string.format("body=%s", body),
       "-F",
-      string.format("reply=%d", reply_id),
+      string.format("reply=%s", reply_id),
       "-f",
       string.format("query=%s", graphql.reply_comment_review)
     }


### PR DESCRIPTION
Commit d6afb4f61dc4 ("gh_exec uses extra args like async_request")
inadvertently broke replying to threads by using the wrong datatype
for the 'reply_id' field. This would result in the following
runtime error when attempting to add a comment to a thread:

```
E5108: Error executing lua: .../gh.nvim/lua/litee/gh/ghcli/init.lua:910: bad argument #2 to 'format' (number expected, got string)
stack traceback:
        [C]: in function 'format'
        .../gh.nvim/lua/litee/gh/ghcli/init.lua:910: in function 'reply_comment_review'
        .../gh.nvim/lua/litee/gh/pr/thread_buffer.lua:678: in function 'reply'
        .../gh.nvim/lua/litee/gh/pr/thread_buffer.lua:848: in function <.../gh.nvim/lua/litee/gh/pr/thread_buffer.lua:823>
```

Fix the datatype so that comments can be posted on threads correctly.

Fixes: d6afb4f61dc4 ("gh_exec uses extra args like async_request")
