### PR TITLE
Remove shell escaping from buffer text extraction

### DIFF
--- a/lua/litee/gh/pr/thread_buffer.lua
+++ b/lua/litee/gh/pr/thread_buffer.lua
@@ -92,7 +92,6 @@ local function extract_text()
     end
     local lines = vim.api.nvim_buf_get_lines(state.buf, state.text_area_off, -1, false)
     local body = vim.fn.join(lines, "\n")
-    body = vim.fn.shellescape(body)
     return body, lines
 end
 


### PR DESCRIPTION
This extra escaping was ending up posted in the body of comments
directly to GitHub, showing up in the final review output. Given the way
that the variables are passed to the gh CLI, this escaping is not
necessary.

Fixes: #118
