### PR TITLE
Use git config ssh remote url to account for custom ssh aliases

### DIFF
--- a/lua/litee/gh/gitcli/init.lua
+++ b/lua/litee/gh/gitcli/init.lua
@@ -143,6 +143,7 @@ function M.get_git_remote()
   if out == nil then
     return nil
   end
-  return out
+  return out:gsub("\n", "")
 end
+
 return M

--- a/lua/litee/gh/gitcli/init.lua
+++ b/lua/litee/gh/gitcli/init.lua
@@ -138,4 +138,11 @@ function M.git_reset_hard(remote, branch)
     return out
 end
 
+function M.get_git_remote()
+  local out = git_exec([[git config --get remote.origin.url]])
+  if out == nil then
+    return nil
+  end
+  return out
+end
 return M

--- a/lua/litee/gh/pr/state.lua
+++ b/lua/litee/gh/pr/state.lua
@@ -529,7 +529,14 @@ function M.get_pr_remote_url()
   if protocol == 'https' then
     remote_url = M.pull_state.pr_raw['head']['repo']['clone_url']
   else
-    remote_url = M.pull_state.pr_raw['head']['repo']['ssh_url']
+    -- Defaults to git remote if set
+    local git_origin_url = gitcli.get_git_remote()
+    if git_origin_url ~= nil then
+      remote_url = git_origin_url
+    else
+      remote_url = M.pull_state.pr_raw['head']['repo']['ssh_url']
+    end
+
   end
 
   return remote_url


### PR DESCRIPTION
I use an alias for my git remote url (so I can use separate `ssh` keys for my work and personal gh accounts). Currently the application will default to using `ssh_url` which is returned from the `repos/{owner}/{repo}/pulls` endpoint. This will always be `git@github.com:<user>/<repo>.git`.

In my case, and probably for others as well, this leads to the plugin being unable to run the `git_fetch` function, causing a failure on startup where the user would see `failed to fetch remote branch` in the upper-right hand corner, and be unable to do anything.

This addition will only do anything if the user is using the `ssh` `git_protocol`, if they are it will default the `remote_url` to whatever is configured in git, via `git config --get remote.origin.url`. Otherwise the old functionality will be used.  